### PR TITLE
Fix parseJSONChunks not working anymore

### DIFF
--- a/src/services/openaiService.ts
+++ b/src/services/openaiService.ts
@@ -151,12 +151,17 @@ export async function sendRequest(msg: ChatCompletionRequestMessage[], model: st
 
 function parseJSONChunks(rawData) {
   try {
-    // Match and parse JSON objects from the concatenated stream data
-    const jsonRegex = /\{"id".*?\]\}/g;
-    return (rawData.match(jsonRegex) || []).map(JSON.parse);
-  } catch (error) {
-    console.error("Error parsing JSON chunk:", error);
-    return null;
+    // Try single object first
+    return [JSON.parse(rawData)];
+  } catch {
+    try {
+      // Match and parse JSON objects from the concatenated stream data
+      const jsonRegex = /\{"id".*?\].*?\}/g;
+      return (rawData.match(jsonRegex) || []).map(JSON.parse);
+    } catch (error) {
+      console.error("Error parsing JSON chunk:", error);
+      return null;
+    }
   }
 }
 


### PR DESCRIPTION
Fix parseJSONChunks not working anymore due to new "obfuscation" field which breaks the `]}` pair it was looking for.

Example:

{"id":"chatcmpl-C3daZKJnTPJurd8azxMLJuaHgPrWG","object":"chat.completion.chunk","created":1754983199,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_b3f1157249","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}]**,"obfuscation":"csx8mpAl2V"**}